### PR TITLE
Update terraform configs for gcp deployment

### DIFF
--- a/deploy/cloud/terraform/gcp/main.template.tf
+++ b/deploy/cloud/terraform/gcp/main.template.tf
@@ -2,7 +2,7 @@
 terraform {
   backend "gcs" {
     bucket  = "{{ .Bucket }}"
-    path    = "{{ .ClusterName }}/terraform/current.tfstate"
+    prefix    = "{{ .ClusterName }}/terraform/current.tfstate"
     project = "{{ .GCPProject }}"
   }
 }

--- a/deploy/cloud/terraform/gcp/module/main.tf
+++ b/deploy/cloud/terraform/gcp/module/main.tf
@@ -14,7 +14,7 @@ resource "google_container_cluster" "libri" {
 
   master_auth {
     username = "admin"
-    password = "demetrius"
+    password = "demetriusijustdontknowwhywoahwoah"
   }
 
   node_config {

--- a/deploy/cloud/terraform/gcp/module/outputs.tf
+++ b/deploy/cloud/terraform/gcp/module/outputs.tf
@@ -1,3 +1,0 @@
-output "cluster_node_addresses" {
-  value = ["${google_container_cluster}.${var.cluster_name}.network_interface.0.access_config.0.assigned_nat_ip"]
-}


### PR DESCRIPTION
1. s/path/prefix/ according to Terraform deprecation docs
2. Augment password size according to GCP min password size req
3. Deleting outputs.tf for now to work around `google_container_cluster`
variable error