### PR TITLE
update deploy/cloud readme

### DIFF
--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -26,6 +26,7 @@ Clusters are hosted in (currently) one of two environments: Minikube or Google C
 * [Go](https://golang.org/doc/install)
 * Go Cobra package: `$ go get -u github.com/spf13/cobra/cobra`
 * Go Terraform package: `$ go get -u github.com/hashicorp/terraform`
+* (for optional testing below): [Docker](https://docs.docker.com/install/)
 
 First, create a local directory to store cluster configuration files: e.g. from libri repo path:
 
@@ -46,9 +47,14 @@ Specify a name for the new cluster and store the path reference:
 
 Create a new [GCP Project](https://console.cloud.google.com/projectcreate); provision a [Storage bucket](https://console.cloud.google.com/storage/browser); and create a [IAM Service Account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) with owner permissions and save the .json keyfile to a local directory.
 
+Set the GCP project name:
+
+    $ gcloud config set project <GCP project name>
+
 Specify the service account keyfile location:
 
-    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile/<keyfile>.json
+    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile/<keyfile>.
+    $ gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
 Customize (with project and bucket name) and execute the following command to create the standard Terraform configuration file.
 
@@ -142,8 +148,10 @@ If using a GCP cluster, get an external address from one of the nodes
     node-exporter-zwr2p           1/1       Running   0          8m        10.142.0.3   gke-libri-dev-default-pool-5ee39584-tljc
     prometheus-1589647967-rj06c   1/1       Running   0          8m        10.24.1.5    gke-libri-dev-default-pool-5ee39584-schn
 
-For now, you need to visually "join" the pods to the instances to get the IP:Port combinations for
-the librarians; for the above, they are
+For now, you need to visually "join" the pods to the instances on pod:NODE == instance:NAME to obtain the IP address for each
+pod, and increment the port numberse starting at 30100 for librarian-0:
+
+e.g., for the above, the IP:Port addresses are as follows:
 - librarians-0: 35.196.233.112:30100
 - librarians-1: 35.185.100.233:30101
 - librarians-2: 104.196.183.229:30102
@@ -152,8 +160,7 @@ the librarians; for the above, they are
 For convenience (and speed), you can run testing commands from an ephemeral container. Test the
 health of a librarian with
 
-    $ librarian_addrs='192.168.99.100:30100,192.168.99.100:30101,192.168.99.100:30102'
-    $ docker pull daedalus2718/libri:snapshot-fa7e6f2
+    $ librarian_addrs='<librarian-0-ip:port>,<librarian-1-ip:port>,<librarian-2-ip:port>'
     $ docker run --rm daedalus2718/libri:latest test health -a "${librarian_addrs}"
 
 Test uploading/downloading entries from the cluster with
@@ -173,7 +180,7 @@ If using minikube, get the Grafana service address
     http://192.168.99.100:30300
 
 If using GCP, use the the same visual "join" as with librarians above to see that the NodePort public address
-for the Grafana service is `104.196.183.229:30300`.
+for the Grafana service is with port 30300.
 
 You can also examine the logs of any pod
 
@@ -230,7 +237,7 @@ When you're finished with a cluster, you have to destroy it manually, which you 
 
     $ kubectl delete -f ${CLUSTER_DIR}/libri.yml
 
-If you have Terraform infrastructure, you'll then use
+If you have Terraform infrastructure, you'll then use the following:
 
     $ pushd ${CLUSTER_DIR}
     $ terraform destroy

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -1,4 +1,4 @@
-## Libri cluster deployment
+# Libri cluster deployment
 
 Deploying a cluster involves creating infrastructure via Terraform and deploying services onto it via Kubernetes.
 
@@ -15,7 +15,7 @@ to outside authors
 If you want to just try out the Kubernetes part first without creating GCP infrastucture,
 you can run it via minikube (currently tested with v0.24, Kubernetes v1.8.0).
 
-#### Initializing Infrastructure
+## Initializing Infrastructure
 
 Clusters are hosted in (currently) one of two environments: Minikube or Google Cloud Platform (GCP).
 

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -30,15 +30,17 @@ Clusters are hosted in (currently) one of two environments: Minikube or Google C
 First, create a local directory to store cluster configuration files: e.g. from libri repo path:
 
     $ cd deploy/cloud && mkdir clusters
-    $ CLUSTERS_DIR="$(pwd)/clusters"
 
-Referencing this path, initialize the cluster as follows:
+Specify a name for the new cluster and store the path reference:
+
+    $ CLUSTER_NAME="my-test-cluster"
+    $ CLUSTERS_DIR="$(pwd)/clusters/${CLUSTER_NAME}"
 
 **Minikube (local):**
 
-    go run cluster.go init minikube \
-        --clusterDir "${CLUSTERS_DIR}"
-        --clusterName my-test-cluster
+    $ go run cluster.go init minikube \
+        --clusterDir "${CLUSTERS_DIR}" \
+        --clusterName "${CLUSTER_NAME}"
 
 **GCP (cloud):**
 
@@ -50,13 +52,13 @@ Specify the service account keyfile location:
 
 Customize (with project and bucket name) and execute the following command to create the standard Terraform configuration file.
 
-    go run cluster.go init gcp \
+    $ go run cluster.go init gcp \
         --clusterDir "${CLUSTERS_DIR}" \
-        --clusterName my-test-cluster \
+        --clusterName "${CLUSTER_NAME}" \
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
         
-Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account e.g.:
+Within the Terraform configuration file located at `clusters/${CLUSTER_NAME}/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account e.g.:
 
     cluster_admin_user = "<user>@<gcp-project>.iam.gserviceaccount.com"
     

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -24,8 +24,8 @@ Clusters are hosted in (currently) one of two environments: Minikube or Google C
 * [Kubernetes-cli](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 * [Go](https://golang.org/doc/install)
-* Go Cobra package: `go get github.com/spf13/cobra/cobra`
-* Go Terraform package: `go get github.com/hashicorp/terraform`
+* Go Cobra package: `go get -u github.com/spf13/cobra/cobra`
+* Go Terraform package: `go get -u github.com/hashicorp/terraform`
 
 First, create a local directory to store cluster configuration files: e.g. from libri repo path:
 
@@ -42,15 +42,21 @@ Referencing this path, initialize the cluster as follows:
 
 **GCP (cloud):**
 
-Create a new [GCP Project](https://console.cloud.google.com/projectcreate) and provision a [Storage bucket](https://console.cloud.google.com/storage/browser).
+Create a new [GCP Project](https://console.cloud.google.com/projectcreate); provision a [Storage bucket](https://console.cloud.google.com/storage/browser); and create a [IAM Service Account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) with owner permissions.
+
+Execute the following to create the standard Terraform configuration file.
 
     go run cluster.go init gcp \
         --clusterDir "${CLUSTERS_DIR}"
         --clusterName my-test-cluster \
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
+        
+Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format <user>@<gcp-project>.iam.gserviceaccount.com).
 
-The `terraform.tfvars` file created in the cluster directory has settings (like number of
+**Further Configuration**
+
+The `terraform.tfvars` file created in the <cluster>/my-test-cluster directory has settings (like number of
 librarians) that can you can change if you want, though the default should be reasonable
 enough to start. The corresponding `variables.tf` file in the directory contains description
 of these settings.

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -52,7 +52,7 @@ Execute the following to create the standard Terraform configuration file.
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
         
-Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format <\user\>@\<gcp-project\>.iam.gserviceaccount.com).
+Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format `<user>@<gcp-project>.iam.gserviceaccount.com`).
 
 **Further Configuration**
 

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -23,16 +23,13 @@ First, create a local directory to store cluster configuration files: e.g.: `<pa
 
 Referencing this path, initialize the cluster as follows:
 
-#### Minikube (local):
+**Minikube (local):**
 
     go run cluster.go init minikube \
         --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster
 
-__GCP (cloud):__
-
-
-
+#### GCP (cloud):
 
     go run cluster.go init gcp \
         --clusterDir </path/to/cluster-dir>

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -53,7 +53,7 @@ Set the GCP project name:
 
 Specify the service account keyfile location:
 
-    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile/<keyfile>.
+    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile/<keyfile>.json
     $ gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
 Customize (with project and bucket name) and execute the following command to create the standard Terraform configuration file.

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -17,22 +17,22 @@ you can run it via minikube (currently tested with v0.24, Kubernetes v1.8.0).
 
 #### Initializing Infrastructure
 
-Clusters are hosted in (currently) one of two environments: minikube or Google Cloud Platform (GCP).
+Clusters are hosted in (currently) one of two environments: Minikube or Google Cloud Platform (GCP).
 
 First, create a local directory to store cluster configuration files: e.g.: `<path to libri>/deploy/cloud/clusters`
 
 Referencing this path, initialize the cluster as follows:
 
-Minikube (local):
+__Minikube (local):__
 
     go run cluster.go init minikube \
         --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster
 
-GCP (cloud):
+__GCP (cloud):__
 
     go run cluster.go init gcp \
-        --clusterDir /path/to/my-test-cluster-dir
+        --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster \
         --bucket my-bucket-name \
         --gcpProject my-gcp-project

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -146,6 +146,7 @@ For convenience (and speed), you can run testing commands from an ephemeral cont
 health of a librarian with
 
     $ librarian_addrs='192.168.99.100:30100,192.168.99.100:30101,192.168.99.100:30102'
+    $ docker pull daedalus2718/libri:snapshot-fa7e6f2
     $ docker run --rm daedalus2718/libri:latest test health -a "${librarian_addrs}"
 
 Test uploading/downloading entries from the cluster with

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -52,9 +52,12 @@ Execute the following to create the standard Terraform configuration file.
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
         
-Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format `<user>@<gcp-project>.iam.gserviceaccount.com`).
+Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account e.g.:
 
-**Further Configuration**
+    cluster_admin_user = "<user>@<gcp-project>.iam.gserviceaccount.com"
+    
+
+**Optional Additional Configuration**
 
 The `terraform.tfvars` file created in the <cluster>/my-test-cluster directory has settings (like number of
 librarians) that can you can change if you want, though the default should be reasonable
@@ -64,9 +67,9 @@ of these settings.
 
 ## Planning
 
-To see what would be created upon spinning up a cluster called `my-cluster`, use
+To see what would be created upon spinning up a cluster called `my-test-cluster`, use
 
-    go run cluster.go plan -d /path/to/my-test-cluster-dir
+    go run cluster.go plan -d ${CLUSTERS_DIR}/my-test-cluster
 
 If your cluster is hosted on GCP, you should first see Terraform plans and then planned dry
 run Kubernetes resources. Minikube clusters have no Terraform component.
@@ -76,7 +79,7 @@ run Kubernetes resources. Minikube clusters have no Terraform component.
 
 Create the cluster and resources with
 
-    go run cluster.go apply -d /path/to/my-test-cluster-dir
+    go run cluster.go apply -d ${CLUSTERS_DIR}/my-test-cluster
 
 You should see the the resources being created (Terraform resources can take up to 5 minutes). See
 the created Kubernetes pods with

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -29,7 +29,9 @@ Referencing this path, initialize the cluster as follows:
         --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster
 
-#### GCP (cloud):
+**GCP (cloud):**
+
+Create a new [GCP Project](https://console.cloud.google.com/projectcreate) and provision a [Storage bucket](https://console.cloud.google.com/storage/browser).
 
     go run cluster.go init gcp \
         --clusterDir </path/to/cluster-dir>

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -84,9 +84,9 @@ run Kubernetes resources. Minikube clusters have no Terraform component.
 
 ## Applying
 
-Create the cluster and resources with
+Create the cluster and resources (enter 'yes' when prompted):
 
-    $ go run cluster.go apply -d ${CLUSTERS_DIR}
+    $ go run cluster.go apply -d ${CLUSTER_DIR}
 
 You should see the the resources being created (Terraform resources can take up to 5 minutes). See
 the created Kubernetes pods with
@@ -184,7 +184,7 @@ You can also examine the logs of any pod
 When you want to update the cluster (e.g., add a librarian or a node), just change the appropriate property in
 `terraform.tfvars` and re-apply
 
-    ./libri-cluster.sh apply ${CLUSTERS_DIR}/my-test-cluster
+    ./libri-cluster.sh apply ${CLUSTER_DIR}
 
 If the change you've applied involves the Prometheus or Grafana configmaps, you have to bounce the service manually
 (since configmaps aren't a formal Kubernetes resources) to pick up the new config. Do this by just deleting the pod
@@ -228,10 +228,10 @@ and letting Kubernetes recreate it
 
 When you're finished with a cluster, you have to destroy it manually, which you can do via
 
-    $ kubectl delete -f ${CLUSTERS_DIR}/my-test-cluster/libri.yml
+    $ kubectl delete -f ${CLUSTER_DIR}/libri.yml
 
 If you have Terraform infrastructure, you'll then use
 
-    $ pushd ${CLUSTERS_DIR}/my-test-cluster
+    $ pushd ${CLUSTER_DIR}
     $ terraform destroy
     $ popd

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -17,21 +17,19 @@ you can run it via minikube (currently tested with v0.24, Kubernetes v1.8.0).
 
 #### Initializing Infrastructure
 
-Clusters are hosted in (currently) one of two environments: minikube or GCP.
+Clusters are hosted in (currently) one of two environments: minikube or Google Cloud Platform (GCP).
 
-First, create a local directory to store configuration files: e.g., `<path to libri>/deploy/cloud/clusters`
+First, create a local directory to store cluster configuration files: e.g.: `<path to libri>/deploy/cloud/clusters`
 
-Initialize a local
-(minikube) cluster as follows:
+Referencing this path, initialize the cluster as follows:
+
+Minikube (local):
 
     go run cluster.go init minikube \
-        --clusterDir /path/to/my-test-cluster-dir
+        --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster
 
-where `/path/to/clusters/dir` is the directory to create the cluster subdirectory in. 
-
-he GCP
-cluster initialization is very similar:
+GCP (cloud):
 
     go run cluster.go init gcp \
         --clusterDir /path/to/my-test-cluster-dir

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -24,8 +24,8 @@ Clusters are hosted in (currently) one of two environments: Minikube or Google C
 * [Kubernetes-cli](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 * [Terraform](https://www.terraform.io/intro/getting-started/install.html)
 * [Go](https://golang.org/doc/install)
-* Go Cobra package: `go get -u github.com/spf13/cobra/cobra`
-* Go Terraform package: `go get -u github.com/hashicorp/terraform`
+* Go Cobra package: `$ go get -u github.com/spf13/cobra/cobra`
+* Go Terraform package: `$ go get -u github.com/hashicorp/terraform`
 
 First, create a local directory to store cluster configuration files: e.g. from libri repo path:
 
@@ -69,7 +69,7 @@ of these settings.
 
 To see what would be created upon spinning up a cluster called `my-test-cluster`, use
 
-    go run cluster.go plan -d ${CLUSTERS_DIR}/my-test-cluster
+    $ go run cluster.go plan -d ${CLUSTERS_DIR}/my-test-cluster
 
 If your cluster is hosted on GCP, you should first see Terraform plans and then planned dry
 run Kubernetes resources. Minikube clusters have no Terraform component.
@@ -79,7 +79,7 @@ run Kubernetes resources. Minikube clusters have no Terraform component.
 
 Create the cluster and resources with
 
-    go run cluster.go apply -d ${CLUSTERS_DIR}/my-test-cluster
+    $ go run cluster.go apply -d ${CLUSTERS_DIR}/my-test-cluster
 
 You should see the the resources being created (Terraform resources can take up to 5 minutes). See
 the created Kubernetes pods with
@@ -176,7 +176,7 @@ You can also examine the logs of any pod
 When you want to update the cluster (e.g., add a librarian or a node), just change the appropriate property in
 `terraform.tfvars` and re-apply
 
-    ./libri-cluster.sh apply /path/to/clusters/my-cluster
+    ./libri-cluster.sh apply ${CLUSTERS_DIR}/my-test-cluster
 
 If the change you've applied involves the Prometheus or Grafana configmaps, you have to bounce the service manually
 (since configmaps aren't a formal Kubernetes resources) to pick up the new config. Do this by just deleting the pod
@@ -220,10 +220,10 @@ and letting Kubernetes recreate it
 
 When you're finished with a cluster, you have to destroy it manually, which you can do via
 
-    $ kubectl delete -f /path/to/clusters/my-cluster/libri.yml
+    $ kubectl delete -f ${CLUSTERS_DIR}/my-test-cluster/libri.yml
 
 If you have Terraform infrastructure, you'll then use
 
-    $ pushd /path/to/clusters/my-cluster
+    $ pushd ${CLUSTERS_DIR}/my-test-cluster
     $ terraform destroy
     $ popd

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -1,9 +1,8 @@
 ## Libri cluster deployment
 
-Deploying a cluster involves creating infrastructure via Terraform and deploying services
-and other things onto it via Kubernetes.
+Deploying a cluster involves creating infrastructure via Terraform and deploying services onto it via Kubernetes.
 
-The components of a libri cluster are
+The components of a Libri cluster are
 - libri-headless: headless `ClusterIP` service for internal DNS resolution among librarians
 - librarians-[0,...,N-1]: `NodePort` services for each of the librarians, making them accessible
 to outside authors
@@ -16,17 +15,23 @@ to outside authors
 If you want to just try out the Kubernetes part first without creating GCP infrastucture,
 you can run it via minikube (currently tested with v0.24, Kubernetes v1.8.0).
 
-#### Initializing
+#### Initializing Infrastructure
 
-Clusters are hosted in (currently) one of two environments: minikube or GCP. Initialize a local
-(minikube) cluster with
+Clusters are hosted in (currently) one of two environments: minikube or GCP.
+
+First, create a local directory to store configuration files: e.g., `<path to libri>/deploy/cloud/clusters`
+
+Initialize a local
+(minikube) cluster as follows:
 
     go run cluster.go init minikube \
         --clusterDir /path/to/my-test-cluster-dir
         --clusterName my-test-cluster
 
-where `/path/to/clusters/dir` is the directory to create the cluster subdirectory in. The GCP
-cluster initialization is very similar
+where `/path/to/clusters/dir` is the directory to create the cluster subdirectory in. 
+
+he GCP
+cluster initialization is very similar:
 
     go run cluster.go init gcp \
         --clusterDir /path/to/my-test-cluster-dir

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -19,14 +19,25 @@ you can run it via minikube (currently tested with v0.24, Kubernetes v1.8.0).
 
 Clusters are hosted in (currently) one of two environments: Minikube or Google Cloud Platform (GCP).
 
-First, create a local directory to store cluster configuration files: e.g.: `<path to libri>/deploy/cloud/clusters`
+**Requirements:**
+
+* [Kubernetes-cli](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* [Terraform](https://www.terraform.io/intro/getting-started/install.html)
+* [Go](https://golang.org/doc/install)
+* Go Cobra package: `go get github.com/spf13/cobra/cobra`
+* Go Terraform package: `go get github.com/hashicorp/terraform`
+
+First, create a local directory to store cluster configuration files: e.g. from libri repo path:
+
+    cd deploy/cloud && mkdir clusters
+    CLUSTERS_DIR="$(pwd)/clusters"
 
 Referencing this path, initialize the cluster as follows:
 
 **Minikube (local):**
 
     go run cluster.go init minikube \
-        --clusterDir </path/to/cluster-dir>
+        --clusterDir "${CLUSTERS_DIR}"
         --clusterName my-test-cluster
 
 **GCP (cloud):**
@@ -34,11 +45,10 @@ Referencing this path, initialize the cluster as follows:
 Create a new [GCP Project](https://console.cloud.google.com/projectcreate) and provision a [Storage bucket](https://console.cloud.google.com/storage/browser).
 
     go run cluster.go init gcp \
-        --clusterDir </path/to/cluster-dir>
+        --clusterDir "${CLUSTERS_DIR}"
         --clusterName my-test-cluster \
-        --bucket my-bucket-name \
-        --gcpProject my-gcp-project
-
+        --bucket <bucket-name> \
+        --gcpProject <gcp-project-name>
 
 The `terraform.tfvars` file created in the cluster directory has settings (like number of
 librarians) that can you can change if you want, though the default should be reasonable

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -56,7 +56,7 @@ enough to start. The corresponding `variables.tf` file in the directory contains
 of these settings.
 
 
-#### Planning
+## Planning
 
 To see what would be created upon spinning up a cluster called `my-cluster`, use
 
@@ -66,7 +66,7 @@ If your cluster is hosted on GCP, you should first see Terraform plans and then 
 run Kubernetes resources. Minikube clusters have no Terraform component.
 
 
-#### Applying
+## Applying
 
 Create the cluster and resources with
 
@@ -99,7 +99,7 @@ and the created services with
     prometheus     10.0.0.133   <nodes>       9090:30090/TCP    4m        app=prometheus
 
 
-#### Testing
+## Testing
 
 If using a local cluster, get the external address for one of the services
 
@@ -148,7 +148,7 @@ If you get timeout issues (especially with remote GCP cluster), try bumping the 
     $ docker run --rm daedalus2718/libri:latest test io -a "${librarian_addrs}" --timeout 20
 
 
-#### Monitoring
+## Monitoring
 
 If using minikube, get the Grafana service address
 
@@ -162,7 +162,7 @@ You can also examine the logs of any pod
 
     $ kubectl logs librarians-1
 
-#### Updating
+## Updating
 
 When you want to update the cluster (e.g., add a librarian or a node), just change the appropriate property in
 `terraform.tfvars` and re-apply
@@ -207,7 +207,7 @@ and letting Kubernetes recreate it
     prometheus-1589647967-0c0bn   1/1       Running   0          1h
 
 
-#### Destroying
+## Destroying
 
 When you're finished with a cluster, you have to destroy it manually, which you can do via
 

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -29,8 +29,8 @@ Clusters are hosted in (currently) one of two environments: Minikube or Google C
 
 First, create a local directory to store cluster configuration files: e.g. from libri repo path:
 
-    cd deploy/cloud && mkdir clusters
-    CLUSTERS_DIR="$(pwd)/clusters"
+    $ cd deploy/cloud && mkdir clusters
+    $ CLUSTERS_DIR="$(pwd)/clusters"
 
 Referencing this path, initialize the cluster as follows:
 
@@ -42,12 +42,16 @@ Referencing this path, initialize the cluster as follows:
 
 **GCP (cloud):**
 
-Create a new [GCP Project](https://console.cloud.google.com/projectcreate); provision a [Storage bucket](https://console.cloud.google.com/storage/browser); and create a [IAM Service Account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) with owner permissions.
+Create a new [GCP Project](https://console.cloud.google.com/projectcreate); provision a [Storage bucket](https://console.cloud.google.com/storage/browser); and create a [IAM Service Account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) with owner permissions and save the .json keyfile to a local directory.
 
-Execute the following to create the standard Terraform configuration file.
+Specify the service account keyfile location:
+
+    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile/<keyfile>.json
+
+Customize (with project and bucket name) and execute the following command to create the standard Terraform configuration file.
 
     go run cluster.go init gcp \
-        --clusterDir "${CLUSTERS_DIR}"
+        --clusterDir "${CLUSTERS_DIR}" \
         --clusterName my-test-cluster \
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -52,7 +52,7 @@ Execute the following to create the standard Terraform configuration file.
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
         
-Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format <user>@<gcp-project>.iam.gserviceaccount.com).
+Within the Terraform configuration file located at `${CLUSTERS_DIR}/my-test-cluster/terraform.tfvars`, customize the `cluster_admin_user` variable to refer to the newly created GCP service account (which has format <\user\>@\<gcp-project\>.iam.gserviceaccount.com).
 
 **Further Configuration**
 

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -23,13 +23,16 @@ First, create a local directory to store cluster configuration files: e.g.: `<pa
 
 Referencing this path, initialize the cluster as follows:
 
-__Minikube (local):__
+#### Minikube (local):
 
     go run cluster.go init minikube \
         --clusterDir </path/to/cluster-dir>
         --clusterName my-test-cluster
 
 __GCP (cloud):__
+
+
+
 
     go run cluster.go init gcp \
         --clusterDir </path/to/cluster-dir>

--- a/deploy/cloud/README.md
+++ b/deploy/cloud/README.md
@@ -34,12 +34,12 @@ First, create a local directory to store cluster configuration files: e.g. from 
 Specify a name for the new cluster and store the path reference:
 
     $ CLUSTER_NAME="my-test-cluster"
-    $ CLUSTERS_DIR="$(pwd)/clusters/${CLUSTER_NAME}"
+    $ CLUSTER_DIR="$(pwd)/clusters/${CLUSTER_NAME}"
 
 **Minikube (local):**
 
     $ go run cluster.go init minikube \
-        --clusterDir "${CLUSTERS_DIR}" \
+        --clusterDir "${CLUSTER_DIR}" \
         --clusterName "${CLUSTER_NAME}"
 
 **GCP (cloud):**
@@ -53,7 +53,7 @@ Specify the service account keyfile location:
 Customize (with project and bucket name) and execute the following command to create the standard Terraform configuration file.
 
     $ go run cluster.go init gcp \
-        --clusterDir "${CLUSTERS_DIR}" \
+        --clusterDir "${CLUSTER_DIR}" \
         --clusterName "${CLUSTER_NAME}" \
         --bucket <bucket-name> \
         --gcpProject <gcp-project-name>
@@ -73,9 +73,10 @@ of these settings.
 
 ## Planning
 
-To see what would be created upon spinning up a cluster called `my-test-cluster`, use
+To see what would be created upon spinning up the new cluster, use
 
-    $ go run cluster.go plan -d ${CLUSTERS_DIR}/my-test-cluster
+    $ export TF_VAR_credentials_file=/path/to/keyfile/<keyfile>.json
+    $ go run cluster.go plan --nokube -d ${CLUSTER_DIR}
 
 If your cluster is hosted on GCP, you should first see Terraform plans and then planned dry
 run Kubernetes resources. Minikube clusters have no Terraform component.
@@ -85,7 +86,7 @@ run Kubernetes resources. Minikube clusters have no Terraform component.
 
 Create the cluster and resources with
 
-    $ go run cluster.go apply -d ${CLUSTERS_DIR}/my-test-cluster
+    $ go run cluster.go apply -d ${CLUSTERS_DIR}
 
 You should see the the resources being created (Terraform resources can take up to 5 minutes). See
 the created Kubernetes pods with


### PR DESCRIPTION
SCRIPT EDITS:

go run cluster.go init
1. can drop "clusterDir" specification -- the script should create /clusters/ and then create /clusters/custerName/ ... and then set ${CLUSTERS_DIR}
2. the service account email address is in the provided json keyfile -- should parse out of there instead of having to manually edit terraform.tfvars
    (CAUTION: currently expertimenter@<drausin project> is the default)

go run cluster.go plan
1. should refer to GOOGLE_APPLICATION_CREDENTIALS (already set) instead of requiring new (but duplicate env var) TF_VAR_credentials_file
2. how to deal w/ it hanging? remove kubernetes commands.

go run cluster.go apply
ERROR: subscription-issue